### PR TITLE
medspacy 1.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-
-channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,43 +6,53 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/medspacy-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 30ead2dd36cc53db544e7ef447c2ac8ca6cf836d49ae57c75e133a8429884fe4
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  # spacy isn't available on s390x
+  skip: True  # [py<38 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8
-    - setuptools >=61.0.0
-    - setuptools-scm >=6.2
-    - wheel
+    - python
     - pip
     - setuptools
+    - setuptools-scm 7.0.4
+    - toml
     - wheel
   run:
-    - python >=3.8
+    - python
     - spacy >=3.4.1,<4.0
     - pyrush >=1.0.8
-    - pysbd ==0.3.4
+    - pysbd 0.3.4
     - jsonschema
-    - medspacy_quickumls ==3.0
+    - medspacy_quickumls 3.0
 
 test:
   imports:
     - medspacy
-  commands:
-    - pip check
+  source_files:
+    - tests/
   requires:
     - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -k "not (test_span_groups or test_overlapping_spans or test_multiword_span or test_load_lang_model or test_execute_example_notebooks)"
 
 about:
-  summary: Library for clinical NLP with spaCy.
   home: https://github.com/medspacy/medspacy
+  dev_url: https://github.com/medspacy/medspacy
+  doc_url: https://github.com/medspacy/medspacy
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  summary: Library for clinical NLP with spaCy
+  description: |
+    MedSpaCy is a library of tools for performing clinical NLP and text processing tasks with the popular spaCy framework. The medspacy package brings together a number of other packages, each of which implements specific functionality for common clinical text processing specific to the clinical domain, such as sentence segmentation, contextual analysis and attribute assertion, and section detection.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/medspacy/medspacy/blob/master/CHANGELOG.md
License: https://github.com/medspacy/medspacy/blob/master/LICENSE
Requirements:
- https://github.com/medspacy/medspacy/blob/master/pyproject.toml
- https://github.com/medspacy/medspacy/blob/master/requirements_tests.txt

Actions:
1. Skip py<38 and s390x
2. Add flags --no-deps --no-build-isolation to script
3. Add pytest command
4. Add license_family
5. Add dev & doc urls
7. Add description & summary

Notes:
- We can't test spacy data models 3.5.0 because we haven't yet them on the defaults channel and old models from spacy 3.3.1 isn't compatible with them. That's why we skip `test_load_lang_model`